### PR TITLE
Added owner attribute to task

### DIFF
--- a/server/models/Task.js
+++ b/server/models/Task.js
@@ -12,6 +12,9 @@ module.exports = (sequelize, DataTypes) => {
         content: {
             type: DataTypes.STRING,
         },
+        owner: {
+            type: DataTypes.STRING,
+        },
         columnOrderNumber: {
             type: DataTypes.INTEGER,
         },

--- a/server/src/datasources/BoardService.js
+++ b/server/src/datasources/BoardService.js
@@ -197,7 +197,7 @@ class BoardService {
         return addedColumn
     }
 
-    async addTaskForColumn(columnId, title, size) {
+    async addTaskForColumn(columnId, title, size, owner, content) {
     /*
       At the time of new tasks' creation we want to display it as the lower most task in its column,
       hence it is given the biggest columnOrderNumber of the column
@@ -212,6 +212,8 @@ class BoardService {
                 columnId,
                 title,
                 size,
+                owner,
+                content,
                 columnOrderNumber: smallestOrderNumber + 1,
             })
         } catch (e) {

--- a/server/src/graphql/resolvers/task-resolvers.js
+++ b/server/src/graphql/resolvers/task-resolvers.js
@@ -8,8 +8,10 @@ const schema = {
     },
 
     Mutation: {
-        addTaskForColumn(root, { columnId, title, size }) {
-            return dataSources.boardService.addTaskForColumn(columnId, title, size)
+        addTaskForColumn(root, {
+            columnId, title, size, owner, content,
+        }) {
+            return dataSources.boardService.addTaskForColumn(columnId, title, size, owner, content)
         },
         deleteTaskById(root, { id }) {
             return dataSources.boardService.deleteTaskById(id)

--- a/server/src/graphql/typedefs/task.graphql
+++ b/server/src/graphql/typedefs/task.graphql
@@ -1,7 +1,8 @@
 type Task {
   id: ID!
   title: String!
-  content: String!
+  content: String
+  owner: String
   size: Float
   column: Column!
   columnOrderNumber: Int!
@@ -14,6 +15,6 @@ type Query {
 }
 
 type Mutation {
-  addTaskForColumn(columnId: ID!, title: String!, size: Float): Task
+  addTaskForColumn(columnId: ID!, title: String!, size: Float, owner: String, content: String ): Task
   deleteTaskById(id: ID!) : ID
 }

--- a/src/components/Task.jsx
+++ b/src/components/Task.jsx
@@ -38,6 +38,13 @@ const Task = ({ task, index, columnId }) => {
                     >
                         <Grid item classes={{ root: classes.taskTitle }}>
                             <h1>{add3Dots(title, titleLimit)}</h1>
+                            {task.owner ? (
+                                <h3>
+                                    owner:
+                                    {' '}
+                                    {task.owner}
+                                </h3>
+                            ) : null}
                             {task.size ? (
                                 <h3>
                                     diff:

--- a/src/components/TaskDialog.jsx
+++ b/src/components/TaskDialog.jsx
@@ -7,10 +7,16 @@ const TaskDialog = ({ dialogStatus, column, toggleDialog }) => {
     const [addTask] = useAddTask(column.id)
     const [title, setTitle] = useState('')
     const [size, setSize] = useState(null)
+    const [owner, setOwner] = useState('')
 
     const handleChange = (event) => {
         setTitle(event.target.value)
     }
+
+    const handleOwnerChange = (event) => {
+        setOwner(event.target.value)
+    }
+
     const handleSizeChange = (event) => {
         if (event.target.value === '') {
             setSize(null)
@@ -26,11 +32,13 @@ const TaskDialog = ({ dialogStatus, column, toggleDialog }) => {
                 columnId: column.id,
                 title,
                 size,
+                owner,
             },
         })
         toggleDialog()
         setTitle('')
         setSize(null)
+        setOwner('')
     }
 
     return (
@@ -53,6 +61,16 @@ const TaskDialog = ({ dialogStatus, column, toggleDialog }) => {
                         value={title}
                         fullWidth
                         onChange={handleChange}
+                    />
+                    <TextField
+                        autoComplete="off"
+                        margin="dense"
+                        name="owner"
+                        label="Owner"
+                        type="text"
+                        value={owner}
+                        fullWidth
+                        onChange={handleOwnerChange}
                     />
                     <TextField
                         autoComplete="off"

--- a/src/graphql/board/boardQueries.js
+++ b/src/graphql/board/boardQueries.js
@@ -26,6 +26,7 @@ export const BOARD_BY_ID = gql`
                     id
                     title
                     size
+                    owner
                 }
             }
         }

--- a/src/graphql/task/taskQueries.js
+++ b/src/graphql/task/taskQueries.js
@@ -17,11 +17,12 @@ export const MOVE_TASK_FROM_COLUMN = gql`
 `
 
 export const ADD_TASK = gql`
-    mutation createTask($columnId: ID!, $title: String!, $size: Float) {
-        addTaskForColumn(columnId: $columnId, title: $title, size: $size) {
+    mutation createTask($columnId: ID!, $title: String!, $size: Float, $owner: String) {
+        addTaskForColumn(columnId: $columnId, title: $title, size: $size, owner: $owner) {
             id
             title
             size
+            owner
         }
     }
 `


### PR DESCRIPTION
When adding the owner attribute to backend, encountered problems with the task.graphql file's settings. Got error message "Cannot return null for non-nullable field Task.content". Figured this was because content had not been defined for addTaskForColumn mutation, so added the content to addTaskForColumn. Still had problems, found out content had been defined mandatory in task.graphql. Changed content to optional in task.graphql to get around this problem without having to create content-attribute to frontend.